### PR TITLE
Add wavedrom sources

### DIFF
--- a/design_discussion/images/wavedrom/COBS_dec_0.json
+++ b/design_discussion/images/wavedrom/COBS_dec_0.json
@@ -1,0 +1,62 @@
+{
+ signal: [
+  {name: 'clk',
+   wave: 'p.......'},
+
+  ['Input',
+   {name: 's_tdata',
+    wave: 'x3442444',
+    data: '3 a b ?',
+    phase: 0.1
+   },
+  ],
+  ['Delay 0',
+   {name: 'm_tdata',
+    wave: 'x.444',
+    data: 'a b ?',
+    phase: 0.1
+   },
+   {name: 'm_tlast',
+    wave: '0..==0..',
+    phase: 0.1
+   },
+   {name: 'm_tvalid',
+    wave: '0.1.=0..',
+    phase: 0
+   },
+  ],
+  ['Delay 1',
+   {name: 'm_tdata',
+    wave: 'x..444',
+    data: 'a b ?',
+    phase: 0.1
+   },
+   {name: 'm_tlast',
+    wave: '0...==0.',
+    phase: 0.1
+   },
+   {name: 'm_tvalid',
+    wave: '0..1.=0.',
+    phase: 0
+   },
+  ],
+  ['Delay 2',
+   {name: 'm_tdata',
+    wave: 'x...444',
+    data: 'a b ?',
+    phase: 0.1
+   },
+   {name: 'm_tlast',
+    wave: '0....==0',
+    phase: 0.1
+   },
+   {name: 'm_tvalid',
+    wave: '0...1.=0',
+    phase: 0
+   },
+  ],
+ ],
+   head: {
+   tick: 0,
+   }   
+}

--- a/design_discussion/images/wavedrom/COBS_dec_1.json
+++ b/design_discussion/images/wavedrom/COBS_dec_1.json
@@ -1,0 +1,92 @@
+{signal:
+ [
+  {name: 'clk',
+   wave: 'p.....................'},
+
+  {name: 'uncoded_data',
+   wave: '2222222222222',
+   data: 'a b 0 c d e 0 0 f g h i 0',
+   phase: -1.9
+  },
+
+  {name: 'next_uncoded',
+   wave: '22222',
+   data: 'l m n p ...',
+   phase: -16.9
+  },
+
+  ['Input',
+   {name: 's_tdata',
+    wave: '2344344433444432344444',
+    data: '0 3 a b 4 c d e 1 5 f g h i 1 0 27 l m n p ...',
+    phase: 0.1
+   },
+  ],
+   
+  {name: 'input_pre_tvalid',
+   wave: '0.1............0.1....',
+   phase: 0.1
+  },
+   
+  {name: 'impossible pre_tlast',
+   wave: '0.............10......',
+   phase: 0.1
+  },
+   
+  {name: 'tdata_d',
+   wave: 'x234434443344443234444',
+   data: '0 3 a b 4 c d e 1 5 f g h i 1 0 27 l m n ...'
+  },
+
+  {name: 'frame_sep',
+   wave: '010.............10....',
+  },
+
+  {name: 'frame_sep_d',
+   wave: '0.10.............10...',
+  },
+
+  {name: 'counter_load',
+   wave: '0.10.10..1.0...1..0...',
+  },
+
+  {name: 'ctr_load',
+   wave: 'p..Pp.Pp..P.p...P..p..'
+  },
+   
+  {name: 'count',
+   wave: 'xxx3553555335555353555',
+   data: '3 2 1 4 3 2 1 1 5 4 3 2 1 1 0 27 26 25 ...',
+   phase: 0.1
+  },
+   
+  ['Output',
+   {name: 'm_tdata',
+    wave: 'xxxx6666666666666xx666',
+    data: 'a b 0 c d e 0 0 f g h i 0 l m ...',
+    phase: 0.1
+   },
+
+   {name: 'm_tlast',
+    wave: '0...............10....',
+    phase: 0.1
+   },
+   
+   {name: 'm_tvalid',
+    wave: '0...1............0.1..',
+    phase: 0.1
+   },
+  ],
+ ],
+   
+ head:
+  {
+   text: ['tspan', {class: 'h2'}, 'COBS Decoder Implementation Timing 1'],
+  },
+   
+ foot:
+  {
+   text: ['tspan', {class: 'muted h5'},
+  'Assumes s_tvalid and m_tready stay high                             2022-12-03 Paul Williamson and Michelle Thompson'],
+  },
+}

--- a/design_discussion/images/wavedrom/COBS_dec_2.json
+++ b/design_discussion/images/wavedrom/COBS_dec_2.json
@@ -1,0 +1,75 @@
+{signal:
+ [
+  {name: 'clk',
+   wave: 'p.........|...........'},
+
+  {name: 'uncoded_data',
+   wave: '22222222|222',
+   data: '2 5 4 c a s e ... x y z',
+   phase: -1.9
+  },
+   
+  {name: 'next_uncoded',
+   wave: '222222',
+   data: 'a b 0 c d ...',
+   phase: -15.9
+  },
+   
+  ['Input',
+   {name: 's_tdata',
+    wave: '2344444444|44423443444',
+    data: '0 FF 2 5 4 c a s e ... x y z 0 3 a b 4 c d ...',
+    phase: 0.1
+   },
+  ],
+   
+  {name: 'tdata_d',
+   wave: 'x234444444|44442344344',
+   data: '0 FF 2 5 4 c a s e ... x y z 0 3 a b 4 c ...',
+   phase: 0.1
+  },
+   
+  {name: 'frame_sep',
+   wave: '010.......|....10.....',
+  },
+
+  {name: 'ctr_load',
+   wave: 'p..Pp.....|.....P.p.Pp'
+  },
+   
+  {name: 'count',
+   wave: 'xxx3555555|55555535535',
+   data: '255 254 253 253 252 251 250 ... 4 3 2 1 0 3 2 1 4  ...',
+   phase: 0.1
+  },
+   
+  ['Output',
+   {name: 'm_tdata',
+    wave: 'xxxx666666|66666xx6666',
+    data: '2 5 4 c a s ... w x y z a b 0 ...',
+    phase: 0.1
+   },
+   
+   {name: 'm_tlast',
+    wave: 'xx0.......|....10.....',
+    phase: 0.1
+   },
+   
+   {name: 'm_tvalid',
+   wave: 'xx0.1.....|.....0.1...',
+   phase: 0.1
+   },
+  ],
+ ],
+  
+ head:
+  {text:
+  ['tspan', {class: 'h2'}, 'COBS Decoder Implementation Timing 2'],
+  },
+   
+ foot:
+  {text:
+   ['tspan', {class: 'muted h5'},
+    'Assumes s_tvalid and m_tready stay high                             2022-12-03 Paul Williamson and Michelle Thompson'],
+  },
+}

--- a/design_discussion/images/wavedrom/COBS_dec_3.json
+++ b/design_discussion/images/wavedrom/COBS_dec_3.json
@@ -1,0 +1,74 @@
+{signal:
+ [
+  {name: 'clk',
+   wave: 'p.........|...........'},
+
+  {name: 'uncoded_data',
+   wave: '22222222|222x222',
+   data: '2 5 4 c a s e ... x y z a b c',
+   phase: -1.9
+  },
+   
+  {name: 'next_uncoded',
+   wave: '22',
+   data: 'd ...',
+   phase: -19.9
+  },
+   
+  ['Input',
+   {name: 's_tdata',
+    wave: '2344444444|44434442344',
+    data: '0 FF 2 5 4 c a s e ... x y z 4 a b c 0 4 d ...',
+    phase: 0.1
+   },
+  ],
+
+  {name: 'tdata_d',
+   wave: 'x234444444|44443444234',
+   data: '0 FF 2 5 4 c a s e ... x y z 4 a b c 0 4 ...',
+   phase: 0.1
+  },
+   
+  {name: 'ctr_load',
+   wave: 'p..Pp.....|.....Pp...P'
+  },
+   
+  {name: 'case_255',
+   wave: '0..1......|.....0.....',
+  },
+   
+  {name: 'count',
+   wave: 'xxx3555555|55555355555',
+   data: '255 254 253 253 252 251 250 ... 4 3 2 1 4 3 2 1 0 ...',
+   phase: 0.1
+  },
+   
+  ['Output',
+   {name: 'm_tdata',
+    wave: 'xxxx666666|66666x666xx',
+    data: '2 5 4 c a s ... w x y z a b c d ...',
+    phase: 0.1
+   },
+   
+   {name: 'm_tlast',
+    wave: 'xx0.......|........10.',
+    phase: 0.1
+   },
+   
+   {name: 'm_tvalid',
+    wave: 'xx0.1.....|.....01..0.',
+    phase: 0.1
+   },
+  ],
+ ],
+   
+ head:
+  {text:
+   ['tspan', {class: 'h2'}, 'COBS Decoder Implementation Timing 3'],
+  },
+   
+ foot:{text:
+  ['tspan', {class: 'muted h5'},
+   'Assumes s_tvalid and m_tready stay high                             2022-12-03 Paul Williamson and Michelle Thompson'],
+  },
+}

--- a/design_discussion/images/wavedrom/COBS_dec_4.json
+++ b/design_discussion/images/wavedrom/COBS_dec_4.json
@@ -1,0 +1,97 @@
+{signal: [
+  {name: 'clk',
+   wave: 'p.....................'},
+  {name: 'uncoded_data',
+   wave: '2x2222x222',
+   data: 'a b c 0 d e f 0',
+   phase: -3.9
+  },
+  {name: 'next_uncoded',
+   wave: '2222',
+   data: 'g h i ...',
+   phase: -17.9
+  },
+  ['Input',
+  {name: 's_tdata',
+   wave: '2x3x4x4434x44xx3234444',
+   data: '0 4 a b c 4 d e f 1 0 4 g h i ...',
+   phase: 0.1
+  },
+   {name: 's_tvalid',
+    wave: '1010101...01.0.1......'
+   },
+   ],
+
+  {name: 'tdata_d',
+   wave: 'x2x3x4x4434x44xx323444',
+   data: '0 4 a b c 4 d e f 1 0 4 g h ...',
+   phase: 0.1
+  },
+   {name: 'tvalid_d',
+    wave: 'x1010101...01.0.1.....'
+   },
+   
+   {name: 'tvalid_dd',
+    wave: 'xx1010101...01.0.1....'
+   },
+   
+   {name: 'frame_sep',
+    wave: 'x10..............10...'
+   },
+
+   {name: 'frame_sep_d',
+    wave: 'x.1.0.............10..'
+   },
+
+   {name: 'counter_load',
+    wave: 'xx010....10.....1..0..',
+   },
+   
+   {name: '~ ctr_load',
+   wave: 'ppplPlplppPplppl.PPPp.',
+  },
+  {name: 'count',
+   wave: 'xxxx3.5.5535.55..32355',
+   data: '4 3 2 1 4 3 2 1 1 0 4 3 ...',
+   phase: 0.1
+  },
+   
+  {name: 'counter_load_d',
+   wave: '0...1.0...10.....1..0.',
+   phase: 0.1
+  },
+
+  {name: 'pre_tvalid',
+   wave: '0.....1...........0.1.',
+   phase: 0.1
+  },
+
+   ['Output',
+  {name: 'm_tdata',
+   wave: 'xxxxxx6.6666.66..6x.66',
+   data: 'a b c 0 d e f 0 g ...',
+   phase: 0.1
+  },
+  {name: 'm_tlast',
+   wave: 'xx0..............10...',
+   phase: 0.1
+  },
+  {name: 'm_tvalid',
+   wave: 'xx0...101...010.1.0.1.',
+   phase: 0.1
+  },
+    ],
+  {name: 'consumed',
+   wave: '8x8888x8xx880.99',
+   data: 'a b c 0 d e f 0 g ...',
+   phase: -6
+  },
+],
+  head:{text:
+  ['tspan', {class: 'h2'}, 'COBS Decoder Implementation Timing 4'],
+  },
+  foot:{text:
+  ['tspan', {class: 'muted h5'},
+   'Assumes m_tready stays high                                                  2022-12-03 Paul Williamson and Michelle Thompson'],
+  },
+}

--- a/design_discussion/images/wavedrom/COBS_dec_5.json
+++ b/design_discussion/images/wavedrom/COBS_dec_5.json
@@ -1,0 +1,95 @@
+{signal: [
+  {name: 'clk',
+   wave: 'p.....................'},
+  {name: 'uncoded_data',
+   wave: '20.....2x20...222222',
+   data: 'z a b p q 0 r s ...',
+   phase: -1.9
+  },
+
+  ['Input',
+  {name: 's_tdata',
+   wave: '3x4x2x2234x42xx3443444',
+   data: '2 z 0 0 0 5 a b 0 3 p q 4 r s ...',
+   phase: 0.1
+  },
+   {name: 's_tvalid',
+    wave: '1010101...01.0.1......'
+   },
+   ],
+
+  {name: 'tdata_d',
+   wave: 'x3x4x2x2234x42xx344344',
+   data: '2 z 0 0 0 5 a b 0 3 p q 4 r ...',
+   phase: 0.1
+  },
+   
+   {name: 'tvalid_d',
+    wave: 'x1010101...01.0.1.....'
+   },
+   
+   {name: 'tvalid_dd',
+    wave: 'xx1010101...01.0.1....'
+   },
+   
+   {name: 'frame_sep',
+    wave: '0....101.0...10.......'
+   },
+   
+   {name: 'frame_sep_d',
+    wave: '0.....1...0...1..0....'
+   },
+
+   {name: 'counter_load',
+    wave: 'x10..10..10.....10.10.'
+   },
+
+   {name: '~ ctr_load',
+   wave: 'ppPlplPlp.Pplppl.Pp.Pp',
+  },
+  {name: 'count',
+   wave: 'xx3.5.5...35.55..35535',
+   data: '2 1 0 0 0 5 4 3 0 3 2 1 4  ...',
+   phase: 0.1
+  },
+
+   {name: 'counter_load_d',
+    wave: 'xx1.0.1.0.10.....10.10'
+   },
+
+
+   {name: 'pre_tvalid',
+    wave: '1.....0....1..0...1...'
+   },
+
+
+   ['Output',
+  {name: 'm_tdata',
+   wave: 'xxxx6.x.x..6.66..66666',
+   data: 'z a b 0 0 p q 0 ...',
+   phase: 0.1
+  },
+  {name: 'm_tlast',
+   wave: '0....10......10.......',
+   phase: 0.1
+  },
+  {name: 'm_tvalid',
+   wave: 'xxxx010....1010...1...',
+   phase: 0.1
+  },
+    ],
+  {name: 'consumed',
+   wave: 'x70....8x80...9999',
+   data: 'z a b p q 0 ...',
+   phase: -4
+  },
+],
+  head:{
+    text: ['tspan', {class: 'h2'}, 'COBS Decoder Implementation Timing 5'],
+    tick: 0
+  },
+  foot:{
+    text: ['tspan', {class: 'muted h5'},
+   'Assumes m_tready stays high                                                  2022-12-03 Paul Williamson and Michelle Thompson'],
+  },
+}

--- a/design_discussion/images/wavedrom/COBS_dec_6.json
+++ b/design_discussion/images/wavedrom/COBS_dec_6.json
@@ -1,0 +1,68 @@
+{signal:
+ [
+  {name: 'clk',
+   wave: 'p.....................'},
+  
+  {name: 'uncoded_data',
+   wave: '22222xxxx22222x22x2x22',
+   data: 'a b c d e f g h i j k l m n o',
+   phase: 0.1
+  },
+
+  ['Input',
+   {name: 's_tdata',
+    wave: '44444....44444.44.4.44',
+    data: 'a b c d e f g h i j k l m n o',
+    phase: 0.1
+   },
+   
+   {name: 's_tvalid',
+    wave: '1.....................'
+   },
+   
+   {name: 'm_tready',
+    wave: '1...0...1....01.0101..',
+   },
+  ],
+   
+  ['Out',
+   {name: 's_tready',
+    wave: '1...0...1....01.0101..',
+   },
+  ],
+   
+  {name: 'tdata_d',
+   wave: 'x4444....444444.44.4.4',
+   data: 'a b c d e f g h i j k l m n',
+   phase: 0.1
+  },
+
+  ['Output',
+   {name: 'm_tdata',
+    wave: '555....55555.55.5.55',
+    data: 'a b c d e f g h i j k l m',
+    phase: -1.9
+   },
+   
+   {name: 'm_tvalid',
+    wave: 'xx1...................',
+    phase: 0.1
+   },
+  ],
+   
+  {name: 'consumed',
+   wave: '77xxxx77777x77x7x777',
+   data: 'a b c d e f g h i j k l m',
+   phase: -1.9
+  },
+ ],
+   
+ head:
+  {text: ['tspan', {class: 'h2'}, 'COBS Decoder Implementation Timing 6'],
+  },
+   
+ foot:
+  {text: ['tspan', {class: 'muted h5'},
+   '2022-12-03 Paul Williamson and Michelle Thompson'],
+  },
+}

--- a/design_discussion/images/wavedrom/README.md
+++ b/design_discussion/images/wavedrom/README.md
@@ -1,0 +1,10 @@
+# COBS Decoder Entity Design Docs
+
+[COBS_dec-Entity-Design.md](COBS_dec-Entity-Design.md) is a low-level design document for the COBS decoder, featuring lots of timing diagrams.
+
+## Timing Diagram Tool
+The timing diagrams are drawn using [WaveDrom](https://wavedrom.com), a tool that converts a simple textual description into timing diagrams. The source files are JSON.
+
+***Important: if you use the standalone interactive version of WaveDromEditor, at least the mac OS version, understand that its document handling is very non-standard. There does not seem to be a save command. If you try to open an existing file in WaveDromEditor, it will instead open the last file you had open. This can lead to loss of data if you expect the program to behave normally.***
+
+All the commands in the standalone interactive version of WaveDromEditor are hiding in a hamburger-style menu in the lower right corner.

--- a/design_discussion/images/wavedrom/README.md
+++ b/design_discussion/images/wavedrom/README.md
@@ -1,7 +1,3 @@
-# COBS Decoder Entity Design Docs
-
-[COBS_dec-Entity-Design.md](COBS_dec-Entity-Design.md) is a low-level design document for the COBS decoder, featuring lots of timing diagrams.
-
 ## Timing Diagram Tool
 The timing diagrams are drawn using [WaveDrom](https://wavedrom.com), a tool that converts a simple textual description into timing diagrams. The source files are JSON.
 


### PR DESCRIPTION
The timing diagrams in the design document were created with the tool WaveDrom, which converts text files in a special JSON format into graphics formats. Thus the full source code for the document includes the JSON files as well as the main Markdown file. This pull request adds those JSON files into the repo.